### PR TITLE
Add real KlumAST documentation fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Quick Documentation fallback for AnnoDoc metadata on compiled Java types, methods, constructors, and fields without attached sources.
 - Javadoc markup and representative block-tag rendering through IntelliJ's documentation UI.
 - IntelliJ fixture coverage using the real AnnoDocimal annotation artifact, including native source/external-Javadoc precedence and missing, blank, malformed, unsupported, or absent annotation content.
+- Compatibility coverage for Quick Documentation on a real KlumAST-generated method from explicit-builder and factory-closure Groovy call sites.
 
 ### Changed
 - Rebuilt the plugin scaffold for Java 21 and IntelliJ IDEA 2025.3+, with the bundled Java plugin as the only runtime platform dependency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnnoDoc Support for IntelliJ IDEA
 
-> **Status: pre-alpha.** The first compiled-Java Quick Documentation fallback is implemented, tested, and verifier-compatible with the initial IntelliJ release range. A real KlumAST integration fixture is still pending.
+> **Status: pre-alpha.** The first milestone behavior is implemented and tested with both a compiled Java fixture and a real KlumAST-generated API used from Groovy. Release identity and publication remain pending.
 
 AnnoDoc Support for IntelliJ IDEA is intended to make documentation preserved in compiled JVM classes available through IntelliJ IDEA's normal Quick Documentation experience.
 
@@ -29,7 +29,7 @@ The current vertical slice:
 - fails silently back to IntelliJ when annotation content is missing, blank, or unreadable;
 - works without project configuration, scanning, indexing, startup activity, or background caches;
 - supports IntelliJ IDEA 2025.3 and 2026.1 initially; and
-- treats plain Java projects as first-class consumers while the KlumAST/Groovy fixture remains separate.
+- treats plain Java projects as first-class consumers while verifying a real KlumAST-generated API through a separate Groovy compatibility fixture.
 
 ## Initial non-goals
 
@@ -48,16 +48,16 @@ The architecture leaves room for additional annotation formats and AnnoDocimal's
 
 ## First milestone
 
-The first milestone is a tested, locally installable plugin ZIP. It must prove the behavior with both:
+The first milestone is a tested, locally installable plugin ZIP. Its fixture suite proves the behavior with both:
 
 1. a small compiled AnnoDocimal fixture without attached sources; and
 2. a real KlumAST-generated API integration fixture.
 
-The final repository name, plugin ID, Java package, and Marketplace identity remain intentionally undecided until that vertical slice works. The current `klum-idea-plugin` repository name is provisional.
+The final repository name, plugin ID, Java package, and Marketplace identity remain intentionally undecided. The current `klum-idea-plugin` repository name is provisional.
 
 ## Development
 
-The plugin is implemented in Java 21 and currently builds against IntelliJ IDEA 2025.3.6 using the IntelliJ Platform Gradle Plugin. It has no production dependency on Kotlin, Groovy, AnnoDocimal, or KlumAST; only IntelliJ's bundled Java plugin is required.
+The plugin is implemented in Java 21 and currently builds against IntelliJ IDEA 2025.3.6 using the IntelliJ Platform Gradle Plugin. It has no production dependency on Kotlin, Groovy, AnnoDocimal, or KlumAST; only IntelliJ's bundled Java plugin is required. Groovy 4 and KlumAST 3 are confined to the compatibility fixture build and test environment.
 
 Run the focused IntelliJ fixture suite with:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
+import org.gradle.api.tasks.bundling.Jar
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
     java
+    groovy
     alias(libs.plugins.intelliJPlatform)
     alias(libs.plugins.changelog)
     alias(libs.plugins.qodana)
@@ -15,6 +17,16 @@ version = providers.gradleProperty("pluginVersion").get()
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+val klumAstFixture = sourceSets.create("klumAstFixture")
+val klumAstFixtureJarFile = layout.buildDirectory.file("test-fixtures/klum-ast-fixture.jar")
+val klumAstFixtureJar = tasks.register<Jar>("klumAstFixtureJar") {
+    archiveFileName = klumAstFixtureJarFile.map { it.asFile.name }
+    destinationDirectory = klumAstFixtureJarFile.map { it.asFile.parentFile }
+    from(klumAstFixture.output) {
+        exclude("META-INF/plugin.xml")
     }
 }
 
@@ -30,6 +42,9 @@ repositories {
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
+    add(klumAstFixture.implementationConfigurationName, libs.groovy)
+    add(klumAstFixture.implementationConfigurationName, libs.klum.ast)
+
     testImplementation(libs.annodocimal.annotations)
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
@@ -49,6 +64,7 @@ dependencies {
 
         testFramework(TestFrameworkType.Platform)
         testFramework(TestFrameworkType.Plugin.Java)
+        testBundledPlugin("org.intellij.groovy")
     }
 }
 
@@ -117,6 +133,11 @@ changelog {
 }
 
 tasks {
+    test {
+        dependsOn(klumAstFixtureJar)
+        systemProperty("annodoc.klumAstFixtureJar", klumAstFixtureJarFile.get().asFile.absolutePath)
+    }
+
     wrapper {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 # libraries
 annodocimal = "0.7.1"
+groovy = "4.0.32"
 junit = "4.13.2"
+klumAst = "3.0.0"
 opentest4j = "1.3.0"
 
 # plugins
@@ -11,7 +13,9 @@ qodana = "2025.1.1"
 
 [libraries]
 annodocimal-annotations = { group = "com.blackbuild.annodocimal", name = "anno-docimal-annotations", version.ref = "annodocimal" }
+groovy = { group = "org.apache.groovy", name = "groovy", version.ref = "groovy" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+klum-ast = { group = "com.blackbuild.klum.ast", name = "klum-ast", version.ref = "klumAst" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 
 [plugins]

--- a/src/klumAstFixture/groovy/fixture/DocumentedModel.groovy
+++ b/src/klumAstFixture/groovy/fixture/DocumentedModel.groovy
@@ -1,0 +1,13 @@
+package fixture
+
+import com.blackbuild.groovy.configdsl.transform.DSL
+
+@DSL
+class DocumentedModel {
+    List<DocumentedItem> items
+}
+
+@DSL
+class DocumentedItem {
+    String value
+}

--- a/src/main/java/org/annodoc/intellij/documentation/AnnoDocRenderer.java
+++ b/src/main/java/org/annodoc/intellij/documentation/AnnoDocRenderer.java
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiParameter;
 import com.intellij.psi.javadoc.PsiDocComment;
 import com.intellij.util.IncorrectOperationException;
 
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,7 +78,7 @@ final class AnnoDocRenderer {
     }
 
     private static String parameterList(PsiMethod method) {
-        return java.util.Arrays.stream(method.getParameterList().getParameters())
+        return Arrays.stream(method.getParameterList().getParameters())
                 .map(PsiParameter::getName)
                 .map(name -> "Object " + name)
                 .collect(Collectors.joining(", "));

--- a/src/test/java/org/annodoc/intellij/documentation/AnnoDocQuickDocumentationTest.java
+++ b/src/test/java/org/annodoc/intellij/documentation/AnnoDocQuickDocumentationTest.java
@@ -32,7 +32,9 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -64,10 +66,10 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
                 libraryJar.getFileName().toString()
         );
         String fixtureLibraryRootUrl = VfsUtil.getUrlForLibraryRoot(libraryJar.toFile());
-        fixtureLibrary = java.util.Arrays.stream(ModuleRootManager.getInstance(getModule()).getOrderEntries())
+        fixtureLibrary = Arrays.stream(ModuleRootManager.getInstance(getModule()).getOrderEntries())
                 .filter(LibraryOrderEntry.class::isInstance)
                 .map(LibraryOrderEntry.class::cast)
-                .filter(entry -> java.util.Arrays.asList(entry.getRootUrls(OrderRootType.CLASSES))
+                .filter(entry -> Arrays.asList(entry.getRootUrls(OrderRootType.CLASSES))
                         .contains(fixtureLibraryRootUrl))
                 .map(LibraryOrderEntry::getLibrary)
                 .findFirst()
@@ -107,7 +109,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
 
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -127,7 +129,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -148,7 +150,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = newExpression.resolveConstructor();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -167,7 +169,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -186,7 +188,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -203,7 +205,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -228,7 +230,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget annoDocTarget = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
         assertNull("Source declarations must not be claimed by the AnnoDoc fallback", annoDocTarget);
@@ -268,7 +270,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         assertFalse(JavaDocumentationProvider.getExternalJavaDocUrl(targetElement).isEmpty());
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
         assertNull("External Javadoc must retain precedence over the AnnoDoc fallback", target);
@@ -284,7 +286,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 
@@ -308,7 +310,7 @@ public final class AnnoDocQuickDocumentationTest extends LightJavaCodeInsightFix
         PsiElement targetElement = myFixture.getElementAtCaret();
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
 

--- a/src/test/java/org/annodoc/intellij/documentation/KlumAstQuickDocumentationTest.java
+++ b/src/test/java/org/annodoc/intellij/documentation/KlumAstQuickDocumentationTest.java
@@ -1,0 +1,82 @@
+package org.annodoc.intellij.documentation;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+import com.intellij.platform.backend.documentation.DocumentationData;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.platform.backend.documentation.PsiDocumentationTargetProvider;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiCompiledElement;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.intellij.testFramework.PsiTestUtil;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public final class KlumAstQuickDocumentationTest extends LightJavaCodeInsightFixtureTestCase {
+    @Override
+    protected @NotNull LightProjectDescriptor getProjectDescriptor() {
+        return JAVA_21;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        addLibrary("real-klum-ast-fixture", Path.of(System.getProperty("annodoc.klumAstFixtureJar")));
+        addLibrary("annodocimal-annotations", libraryJarContaining(AnnoDoc.class));
+    }
+
+    public void testQuickDocumentationReadsAnnoDocFromRealKlumAstGeneratedMethodAtGroovyCallSite() {
+        PsiClass builderClass = JavaPsiFacade.getInstance(getProject()).findClass(
+                "fixture.DocumentedModel._RW",
+                GlobalSearchScope.allScope(getProject())
+        );
+        assertNotNull("The generated KlumAST builder must be available as compiled PSI", builderClass);
+
+        myFixture.configureByText(
+                "Usage.groovy",
+                """
+                import fixture.DocumentedModel._RW as DocumentedModelBuilder
+
+                DocumentedModelBuilder builder
+                builder.it<caret>em {}
+                """
+        );
+
+        PsiElement originalElement = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+        PsiElement targetElement = myFixture.getElementAtCaret();
+        assertInstanceOf(targetElement, PsiMethod.class);
+        assertInstanceOf(targetElement, PsiCompiledElement.class);
+
+        DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
+                .map(provider -> provider.documentationTarget(targetElement, originalElement))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("The registered provider must claim the real KlumAST-generated method", target);
+        DocumentationData documentation = assertInstanceOf(target.computeDocumentation(), DocumentationData.class);
+        assertTrue(documentation.getHtml().contains("Creates a new 'item' and adds it to the 'items' collection."));
+    }
+
+    private void addLibrary(String name, Path jar) {
+        PsiTestUtil.addLibrary(getModule(), name, jar.getParent().toString(), jar.getFileName().toString());
+    }
+
+    private static Path libraryJarContaining(Class<?> type) throws Exception {
+        URL classResource = type.getResource(type.getSimpleName() + ".class");
+        if (classResource == null || !"jar".equals(classResource.getProtocol())) {
+            throw new IllegalStateException("Cannot locate test artifact containing " + type.getName());
+        }
+        String resourceUrl = classResource.toExternalForm();
+        int entrySeparator = resourceUrl.indexOf("!/");
+        return Path.of(URI.create(resourceUrl.substring("jar:".length(), entrySeparator)));
+    }
+}

--- a/src/test/java/org/annodoc/intellij/documentation/KlumAstQuickDocumentationTest.java
+++ b/src/test/java/org/annodoc/intellij/documentation/KlumAstQuickDocumentationTest.java
@@ -4,12 +4,10 @@ import com.blackbuild.annodocimal.annotations.AnnoDoc;
 import com.intellij.platform.backend.documentation.DocumentationData;
 import com.intellij.platform.backend.documentation.DocumentationTarget;
 import com.intellij.platform.backend.documentation.PsiDocumentationTargetProvider;
-import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiCompiledElement;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
-import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
@@ -34,12 +32,6 @@ public final class KlumAstQuickDocumentationTest extends LightJavaCodeInsightFix
     }
 
     public void testQuickDocumentationReadsAnnoDocFromRealKlumAstGeneratedMethodAtGroovyCallSite() {
-        PsiClass builderClass = JavaPsiFacade.getInstance(getProject()).findClass(
-                "fixture.DocumentedModel._RW",
-                GlobalSearchScope.allScope(getProject())
-        );
-        assertNotNull("The generated KlumAST builder must be available as compiled PSI", builderClass);
-
         myFixture.configureByText(
                 "Usage.groovy",
                 """
@@ -50,20 +42,9 @@ public final class KlumAstQuickDocumentationTest extends LightJavaCodeInsightFix
                 """
         );
 
-        PsiElement originalElement = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
-        PsiElement targetElement = myFixture.getElementAtCaret();
-        assertInstanceOf(targetElement, PsiMethod.class);
-        assertInstanceOf(targetElement, PsiCompiledElement.class);
-
-        DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
-                .map(provider -> provider.documentationTarget(targetElement, originalElement))
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElse(null);
-
-        assertNotNull("The registered provider must claim the real KlumAST-generated method", target);
-        DocumentationData documentation = assertInstanceOf(target.computeDocumentation(), DocumentationData.class);
-        assertTrue(documentation.getHtml().contains("Creates a new 'item' and adds it to the 'items' collection."));
+        assertTrue(quickDocumentationAtCaret().contains(
+                "Creates a new 'item' and adds it to the 'items' collection."
+        ));
     }
 
     public void testQuickDocumentationReadsAnnoDocInsideKlumAstFactoryClosure() {
@@ -78,10 +59,18 @@ public final class KlumAstQuickDocumentationTest extends LightJavaCodeInsightFix
                 """
         );
 
+        assertTrue(quickDocumentationAtCaret().contains(
+                "Creates a new 'item' and adds it to the 'items' collection."
+        ));
+    }
+
+    private String quickDocumentationAtCaret() {
         PsiElement originalElement = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
-        PsiElement targetElement = myFixture.getElementAtCaret();
-        assertInstanceOf(targetElement, PsiMethod.class);
+        PsiMethod targetElement = assertInstanceOf(myFixture.getElementAtCaret(), PsiMethod.class);
         assertInstanceOf(targetElement, PsiCompiledElement.class);
+        PsiClass containingClass = targetElement.getContainingClass();
+        assertNotNull(containingClass);
+        assertEquals("fixture.DocumentedModel._RW", containingClass.getQualifiedName());
 
         DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
                 .map(provider -> provider.documentationTarget(targetElement, originalElement))
@@ -89,9 +78,9 @@ public final class KlumAstQuickDocumentationTest extends LightJavaCodeInsightFix
                 .findFirst()
                 .orElse(null);
 
-        assertNotNull("The registered provider must claim the generated method inside the factory closure", target);
+        assertNotNull("The registered provider must claim the real KlumAST-generated method", target);
         DocumentationData documentation = assertInstanceOf(target.computeDocumentation(), DocumentationData.class);
-        assertTrue(documentation.getHtml().contains("Creates a new 'item' and adds it to the 'items' collection."));
+        return documentation.getHtml();
     }
 
     private void addLibrary(String name, Path jar) {

--- a/src/test/java/org/annodoc/intellij/documentation/KlumAstQuickDocumentationTest.java
+++ b/src/test/java/org/annodoc/intellij/documentation/KlumAstQuickDocumentationTest.java
@@ -66,6 +66,34 @@ public final class KlumAstQuickDocumentationTest extends LightJavaCodeInsightFix
         assertTrue(documentation.getHtml().contains("Creates a new 'item' and adds it to the 'items' collection."));
     }
 
+    public void testQuickDocumentationReadsAnnoDocInsideKlumAstFactoryClosure() {
+        myFixture.configureByText(
+                "Usage.groovy",
+                """
+                import fixture.DocumentedModel
+
+                DocumentedModel.Create.With {
+                    it<caret>em {}
+                }
+                """
+        );
+
+        PsiElement originalElement = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+        PsiElement targetElement = myFixture.getElementAtCaret();
+        assertInstanceOf(targetElement, PsiMethod.class);
+        assertInstanceOf(targetElement, PsiCompiledElement.class);
+
+        DocumentationTarget target = PsiDocumentationTargetProvider.EP_NAME.getExtensionList().stream()
+                .map(provider -> provider.documentationTarget(targetElement, originalElement))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("The registered provider must claim the generated method inside the factory closure", target);
+        DocumentationData documentation = assertInstanceOf(target.computeDocumentation(), DocumentationData.class);
+        assertTrue(documentation.getHtml().contains("Creates a new 'item' and adds it to the 'items' collection."));
+    }
+
     private void addLibrary(String name, Path jar) {
         PsiTestUtil.addLibrary(getModule(), name, jar.getParent().toString(), jar.getFileName().toString());
     }


### PR DESCRIPTION
## What changed

- add a dedicated test fixture source set that compiles a real KlumAST model
- package the generated API into a compiled, source-free fixture JAR
- exercise the registered Quick Documentation extension from Groovy call sites
- cover both an explicit generated builder alias and the idiomatic KlumAST factory closure
- keep Groovy, KlumAST, and AnnoDocimal dependencies confined to test infrastructure
- apply the repository's import-first Java style and update milestone documentation

## Why

The first AnnoDoc vertical slice needs evidence that the generic documentation fallback works for the actual generated API shape used by KlumAST, not only synthetic Java fixtures. This fixture verifies that IntelliJ resolves the generated `_RW.item` method from realistic Groovy usages and that the plugin renders its AnnoDoc annotation without attached library sources.

## Impact

Production behavior remains generic and has no Groovy, KlumAST, or AnnoDocimal runtime dependency. The packaged plugin contains only the plugin JAR; the additional dependencies and generated fixture are test-scoped.

## Validation

- `./gradlew check verifyPlugin`
- compatible with IntelliJ IDEA 2025.3.6
- compatible with IntelliJ IDEA 2026.1.4
- compatible with IntelliJ IDEA 2026.2 EAP
- production distribution audited to contain only the plugin JAR
- test fixture JAR audited to contain generated classes without sources

The verifier reports existing experimental API usage on 2025.3 and 2026.1; 2026.2 EAP verifies without those warnings.
