### PR TITLE
Prepare 0.1.0-alpha.1 Marketplace test candidate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}  # Check the pull request head rather than its merge commit.
           fetch-depth: 0  # a full history is required for pull request analysis
 
       # Set up the Java environment for the next steps
@@ -199,7 +199,7 @@ jobs:
         run: |
           VERSION=$(./gradlew properties --property version --quiet --console=plain | tail -n 1 | cut -f2- -d ' ')
           RELEASE_NOTE="./build/tmp/release_note.txt"
-          ./gradlew getChangelog --unreleased --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
+          ./gradlew getChangelog --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
           
           if gh release view "$VERSION" > /dev/null 2>&1; then
             echo "Release $VERSION already exists; preserving it."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,27 +32,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set up the Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       # Build plugin
       - name: Build plugin
@@ -63,18 +56,16 @@ jobs:
         id: artifact
         shell: bash
         run: |
-          cd ${{ github.workspace }}/build/distributions
-          FILENAME=`ls *.zip`
-          unzip "$FILENAME" -d content
-
-          echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
+          FILENAME=$(find "${{ github.workspace }}/build/distributions" -maxdepth 1 -name '*.zip' -printf '%f\\n')
+          test -n "$FILENAME"
+          echo "filename=${FILENAME}" >> "$GITHUB_OUTPUT"
 
       # Store an already-built plugin as an artifact for downloading
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifact.outputs.filename }}
-          path: ./build/distributions/content/*/*
+          path: ./build/distributions/${{ steps.artifact.outputs.filename }}
 
   # Run tests and upload a code coverage report
   test:
@@ -83,27 +74,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set up the Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 
@@ -114,7 +98,7 @@ jobs:
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
@@ -137,30 +121,23 @@ jobs:
       pull-requests: write
     steps:
 
-      # Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
 
       # Set up the Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2025.1.1
+        uses: JetBrains/qodana-action@v2026.1.3
         with:
           cache-default-branch-only: true
 
@@ -171,27 +148,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set up the Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 
@@ -202,7 +172,7 @@ jobs:
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
@@ -220,18 +190,9 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      # Remove old release drafts by using the curl request for the available releases with a draft flag
-      - name: Remove Old Release Drafts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/{owner}/{repo}/releases \
-            --jq '.[] | select(.draft == true) | .id' \
-            | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
-
-      # Create a new release draft which is not publicly visible and requires manual acceptance
+      # Preserve existing releases and prepare the candidate as a draft for maintainer review.
       - name: Create Release Draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -240,7 +201,13 @@ jobs:
           RELEASE_NOTE="./build/tmp/release_note.txt"
           ./gradlew getChangelog --unreleased --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
           
+          if gh release view "$VERSION" > /dev/null 2>&1; then
+            echo "Release $VERSION already exists; preserving it."
+            exit 0
+          fi
+
           gh release create $VERSION \
             --draft \
+            --target "$GITHUB_SHA" \
             --title $VERSION \
             --notes-file $RELEASE_NOTE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,62 +1,63 @@
-# GitHub Actions Workflow created for handling the release process based on the draft release prepared with the Build workflow.
-# Running the publishPlugin task requires all the following secrets to be provided: PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN.
-# See https://plugins.jetbrains.com/docs/intellij/plugin-signing.html for more information.
-
+# Publishing is deliberately a maintainer-dispatched action. Creating or promoting a
+# GitHub release alone never sends a plugin to JetBrains Marketplace.
 name: Release
+
 on:
-  release:
-    types: [prereleased, released]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published alpha GitHub release tag to publish
+        required: true
+        type: string
+      confirmation:
+        description: Type publish to confirm Marketplace publication
+        required: true
+        type: string
 
 jobs:
-
-  # Prepare and publish the plugin to JetBrains Marketplace repository
   release:
     name: Publish Plugin
+    if: inputs.confirmation == 'publish'
     runs-on: ubuntu-latest
+    environment: marketplace
     permissions:
       contents: write
-      pull-requests: write
     steps:
+      - name: Validate published alpha release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          gh release view "$RELEASE_TAG" --json isDraft,isPrerelease --jq '
+            if .isDraft then error("the release must be published before Marketplace publication")
+            elif (.isPrerelease | not) then error("only a GitHub prerelease may publish an alpha plugin")
+            else empty end
+          '
 
-      # Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-
-      # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.release_tag }}
 
-      # Set up the Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
-      # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 
-      # Update the Unreleased section with the current release note
-      - name: Patch Changelog
-        if: ${{ github.event.release.body != '' }}
+      - name: Validate release version
         env:
-          CHANGELOG: ${{ github.event.release.body }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          RELEASE_NOTE="./build/tmp/release_note.txt"
-          mkdir -p "$(dirname "$RELEASE_NOTE")"
-          echo "$CHANGELOG" > $RELEASE_NOTE
+          VERSION=$(./gradlew properties --property version --quiet --console=plain | tail -n 1 | cut -f2- -d ' ')
+          test "$VERSION" = "$RELEASE_TAG"
+          case "$VERSION" in *-alpha.*) ;; *) echo "Release version must use the alpha channel." >&2; exit 1;; esac
 
-          ./gradlew patchChangelog --release-note-file=$RELEASE_NOTE
-
-      # Publish the plugin to JetBrains Marketplace
       - name: Publish Plugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
@@ -65,36 +66,7 @@ jobs:
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: ./gradlew publishPlugin
 
-      # Upload an artifact as a release asset
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
-
-      # Create a pull request
-      - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
-          LABEL="release changelog"
-
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-
-          git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
-          git push --set-upstream origin $BRANCH
-          
-          gh label create "$LABEL" \
-            --description "Pull requests with release changelog update" \
-            --force \
-            || true
-
-          gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --label "$LABEL" \
-            --head $BRANCH
+        run: gh release upload ${{ inputs.release_tag }} ./build/distributions/*.zip

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -33,18 +33,18 @@ jobs:
 
       # Check out the current repository
       - name: Fetch Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set up the Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # AnnoDoc Support for IntelliJ IDEA Changelog
 
 ## [Unreleased]
+
+## [0.1.0-alpha.1]
 ### Added
 - Quick Documentation fallback for AnnoDoc metadata on compiled Java types, methods, constructors, and fields without attached sources.
 - Javadoc markup and representative block-tag rendering through IntelliJ's documentation UI.
@@ -13,3 +15,4 @@
 - Adopted Blackbuild's permanent AnnoDoc Support identity and repository coordinates.
 - Rebuilt the plugin scaffold for Java 21 and IntelliJ IDEA 2025.3+, with the bundled Java plugin as the only runtime platform dependency.
 - Removed the abandoned Kotlin template services, startup activity, and tool window.
+- Prepared a credential-driven, maintainer-dispatched Marketplace publishing workflow for the alpha channel.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ Build a locally installable plugin ZIP with:
 ```shell
 ./gradlew buildPlugin
 ```
+
+Maintainers should follow [the release procedure](docs/releasing.md) before publishing a candidate.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnnoDoc Support for IntelliJ IDEA
 
-> **Status: pre-alpha.** The first milestone behavior is implemented and tested with both a compiled Java fixture and a real KlumAST-generated API used from Groovy. Marketplace publication remains pending.
+> **Status: 0.1.0-alpha.1 release candidate.** The first milestone behavior is implemented and tested with both a compiled Java fixture and a real KlumAST-generated API used from Groovy. Marketplace publication remains pending explicit maintainer approval.
 
 AnnoDoc Support for IntelliJ IDEA is intended to make documentation preserved in compiled JVM classes available through IntelliJ IDEA's normal Quick Documentation experience.
 
@@ -41,14 +41,14 @@ The first version will not provide:
 - a public extension API;
 - a custom documentation window or action;
 - a per-project enable/disable switch;
-- Marketplace publication or signing; or
+- automatic Marketplace publication; or
 - a compatibility promise for JetBrains products other than IntelliJ IDEA.
 
 The architecture leaves room for additional annotation formats and AnnoDocimal's proposed structured annotation model without implementing those features prematurely. See [Architecture](docs/architecture.md).
 
 ## First milestone
 
-The first milestone is a tested, locally installable plugin ZIP. Its fixture suite proves the behavior with both:
+The `0.1.0-alpha.1` release candidate is a tested, locally installable plugin ZIP. Its fixture suite proves the behavior with both:
 
 1. a small compiled AnnoDocimal fixture without attached sources; and
 2. a real KlumAST-generated API integration fixture.

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -1,0 +1,38 @@
+# 0.1.0-alpha.1 release-candidate validation
+
+## Release controls
+
+`pluginVersion = 0.1.0-alpha.1` maps to the JetBrains Marketplace `alpha` channel through the IntelliJ Platform Gradle Plugin publishing configuration. The build workflow prepares a GitHub draft release only after its build, test, Qodana, and verifier jobs succeed on `main`; it preserves existing drafts and releases rather than deleting them.
+
+Marketplace publication is not triggered by creating, publishing, or promoting a GitHub release. A maintainer must first publish the GitHub release as a prerelease, then manually dispatch the `Release` workflow with its exact tag and the literal confirmation `publish`. The workflow checks both conditions, checks out the tag, verifies that the Gradle version equals the tag and uses the alpha suffix, then uses only GitHub repository secrets for signing and publication.
+
+## Dependency triage on 2026-07-15
+
+Applicable updates adopted for this candidate:
+
+- Qodana Gradle plugin, GitHub Action, and JVM Community linter image: `2026.1.3`, with Java 21 retained.
+- `actions/checkout@v7`, `actions/setup-java@v5`, `gradle/actions/setup-gradle@v6`, and `actions/upload-artifact@v7`. These replace the Node.js 20-era action lines that generated runtime deprecation notices on GitHub-hosted runners. The obsolete disk-space action was removed from the build workflow rather than retaining an unsupported runtime solely for template cleanup.
+
+Obsolete Dependabot proposals are not applicable because the Java-only rebuild no longer applies their dependencies:
+
+- `org.jetbrains.kotlin.jvm` (PR #15)
+- `org.jetbrains.kotlinx.kover` (PR #12)
+
+The old changelog and IntelliJ Platform Gradle Plugin proposals (PRs #21 and #20) were superseded by versions already present on the corrected main branch. The remaining current action and Qodana proposals (PRs #24–#28 and #3) were triaged by their patches and incorporated locally; no dependency pull request was merged or changed.
+
+## Documentation-target API risk
+
+The plugin uses `PsiDocumentationTargetProvider` and `DocumentationTarget` because JetBrains documents the Documentation Target API as the replacement for the deprecated Documentation Provider API. In the pinned IntelliJ IDEA 2025.3.6 SDK, the provider API is marked `ApiStatus.OverrideOnly` and its extension-point field is `ApiStatus.Internal`; the JetBrains extension-point catalog labels the documentation-target path experimental. The older provider API is not a stable replacement and cannot provide the same fallback integration without using deprecated APIs.
+
+This is an accepted compatibility risk for the 2025.3/2026.1 release lines. Keep `verifyPlugin` required for both supported IntelliJ IDEA lines and re-evaluate the provider when JetBrains promotes a stable documentation fallback seam.
+
+## Manual IDEA smoke test
+
+Automated verification cannot install into a user-managed IDEA instance. Before approving Marketplace publication, install `build/distributions/annodoc-intellij-0.1.0-alpha.1.zip` from disk in both IntelliJ IDEA 2025.3 and 2026.1, then record the following observations:
+
+1. In a plain Java project using the compiled AnnoDoc fixture without attached sources, invoke Quick Documentation on a documented type, method, field, and constructor; all should show the annotation-carried documentation.
+2. In a Groovy project using the KlumAST fixture, invoke Quick Documentation on a generated DSL API; its AnnoDoc documentation should appear without making Groovy a plugin runtime dependency.
+3. Invoke Quick Documentation where ordinary source Javadoc is available; native documentation must win.
+4. Invoke Quick Documentation on an unannotated or malformed/blank AnnoDoc declaration; no error or fabricated documentation should appear.
+
+If signing secrets are configured in the execution environment, run `./gradlew signPlugin verifyPluginSignature` and inspect only its success status and signed archive. Do not print or write the credential values. Otherwise, signing remains a maintainer-gated validation step.

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,7 +24,7 @@ The old changelog and IntelliJ Platform Gradle Plugin proposals (PRs #21 and #20
 
 The plugin uses `PsiDocumentationTargetProvider` and `DocumentationTarget` because JetBrains documents the Documentation Target API as the replacement for the deprecated Documentation Provider API. In the pinned IntelliJ IDEA 2025.3.6 SDK, the provider API is marked `ApiStatus.OverrideOnly` and its extension-point field is `ApiStatus.Internal`; the JetBrains extension-point catalog labels the documentation-target path experimental. The older provider API is not a stable replacement and cannot provide the same fallback integration without using deprecated APIs.
 
-This is an accepted compatibility risk for the 2025.3/2026.1 release lines. Keep `verifyPlugin` required for both supported IntelliJ IDEA lines and re-evaluate the provider when JetBrains promotes a stable documentation fallback seam.
+`verifyPlugin` reports no compatibility errors for IDEA 2025.3, 2026.1, or the configured 2026.2 EAP. It reports six experimental references for 2025.3 (the documentation target presentation builders and `Pointer.delegatingPointer`) and two for 2026.1 (the pointer interface and its delegating method); the configured EAP reports none. These types are required to implement the target contract, so this is an accepted compatibility risk for the 2025.3/2026.1 release lines. Keep `verifyPlugin` required and re-evaluate the provider when JetBrains promotes a stable documentation fallback seam.
 
 ## Manual IDEA smoke test
 

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -1,10 +1,6 @@
 # 0.1.0-alpha.1 release-candidate validation
 
-## Release controls
-
-`pluginVersion = 0.1.0-alpha.1` maps to the JetBrains Marketplace `alpha` channel through the IntelliJ Platform Gradle Plugin publishing configuration. The build workflow prepares a GitHub draft release only after its build, test, Qodana, and verifier jobs succeed on `main`; it preserves existing drafts and releases rather than deleting them.
-
-Marketplace publication is not triggered by creating, publishing, or promoting a GitHub release. A maintainer must first publish the GitHub release as a prerelease, then manually dispatch the `Release` workflow with its exact tag and the literal confirmation `publish`. The workflow checks both conditions, checks out the tag, verifies that the Gradle version equals the tag and uses the alpha suffix, then uses only GitHub repository secrets for signing and publication.
+The maintainer procedure for drafting, approving, signing, and publishing a release is in [Releasing AnnoDoc Support](releasing.md). This document records the validation evidence for the `0.1.0-alpha.1` candidate.
 
 ## Dependency triage on 2026-07-15
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,35 @@
+# Releasing AnnoDoc Support
+
+This procedure is for maintainers preparing an IntelliJ Marketplace release. It does not authorize or automate publication: publishing remains an explicit maintainer decision after all release-candidate checks are complete.
+
+## Prepare the candidate
+
+1. Set `pluginVersion` in `gradle.properties` to the intended SemVer version.
+2. For a prerelease such as `0.1.0-alpha.1`, confirm the suffix maps to the intended Marketplace channel. The build derives the channel from the text between `-` and the next `.`; this version publishes to `alpha`.
+3. Move the completed notes from `Unreleased` to a heading for that exact version in `CHANGELOG.md`.
+4. Run `./gradlew check verifyPlugin buildPlugin` and inspect the ZIP as described in [release-testing.md](release-testing.md).
+5. Complete and record the manual IDEA smoke test for every supported IDEA line.
+
+## Create and approve the GitHub release
+
+After the Build workflow succeeds on `main`, it creates a draft GitHub release for the version and its changelog notes. It preserves an existing draft or release with the same tag; it never deletes prior releases.
+
+Review the draft’s tag, notes, and attached build evidence. When every acceptance criterion is satisfied, a maintainer must explicitly publish it as a **prerelease**. Publishing the GitHub release alone does not publish to JetBrains Marketplace.
+
+## Publish to JetBrains Marketplace
+
+The `Release` GitHub Actions workflow has no release-event trigger. A maintainer must manually dispatch it with:
+
+- `release_tag`: the published GitHub prerelease tag, exactly matching `pluginVersion`;
+- `confirmation`: the literal value `publish`.
+
+The workflow rejects drafts, stable GitHub releases, non-alpha versions, and a tag/version mismatch. It checks out the tag, signs the plugin, publishes it to the Marketplace, and uploads the resulting ZIP to that GitHub release.
+
+Configure these repository secrets before dispatching the workflow:
+
+- `PUBLISH_TOKEN`
+- `CERTIFICATE_CHAIN`
+- `PRIVATE_KEY`
+- `PRIVATE_KEY_PASSWORD`
+
+Never add credentials to repository files, logs, command lines, or issue comments. If the secrets are unavailable, do not dispatch the publishing workflow; perform only the credential-independent checks and leave signing/publication as an explicit remaining maintainer action.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.blackbuild.annodoc.intellij
 pluginName = AnnoDoc Support
 pluginRepositoryUrl = https://github.com/blackbuild/annodoc-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = 0.1.0-alpha.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 253

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ opentest4j = "1.3.0"
 # plugins
 changelog = "2.4.0"
 intelliJPlatform = "2.18.1"
-qodana = "2025.1.1"
+qodana = "2026.1.3"
 
 [libraries]
 annodocimal-annotations = { group = "com.blackbuild.annodocimal", name = "anno-docimal-annotations", version.ref = "annodocimal" }

--- a/qodana.yml
+++ b/qodana.yml
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/help/qodana/qodana-yaml.html
 
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2024.3
+linter: jetbrains/qodana-jvm-community:2026.1.3
 projectJDK: "21"
 profile:
   name: qodana.recommended

--- a/qodana.yml
+++ b/qodana.yml
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/help/qodana/qodana-yaml.html
 
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2026.1.3
+linter: jetbrains/qodana-jvm-community:2026.1
 projectJDK: "21"
 profile:
   name: qodana.recommended

--- a/src/main/java/com/blackbuild/annodoc/intellij/documentation/AnnoDocDocumentationTargetProvider.java
+++ b/src/main/java/com/blackbuild/annodoc/intellij/documentation/AnnoDocDocumentationTargetProvider.java
@@ -9,13 +9,14 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierListOwner;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public final class AnnoDocDocumentationTargetProvider implements PsiDocumentationTargetProvider {
     @Override
-    public @Nullable DocumentationTarget documentationTarget(PsiElement element, @Nullable PsiElement originalElement) {
+    public @Nullable DocumentationTarget documentationTarget(@NotNull PsiElement element, @Nullable PsiElement originalElement) {
         if (!(element instanceof PsiModifierListOwner owner)
                 || !(owner instanceof PsiClass || owner instanceof PsiMethod || owner instanceof PsiField)
                 || !(owner instanceof PsiCompiledElement)) {

--- a/src/main/java/com/blackbuild/annodoc/intellij/documentation/AnnoDocDocumentationTargetProvider.java
+++ b/src/main/java/com/blackbuild/annodoc/intellij/documentation/AnnoDocDocumentationTargetProvider.java
@@ -17,10 +17,8 @@ public final class AnnoDocDocumentationTargetProvider implements PsiDocumentatio
     @Override
     public @Nullable DocumentationTarget documentationTarget(PsiElement element, @Nullable PsiElement originalElement) {
         if (!(element instanceof PsiModifierListOwner owner)
-                || (!(element instanceof PsiClass)
-                && !(element instanceof PsiMethod)
-                && !(element instanceof PsiField))
-                || !(element instanceof PsiCompiledElement)) {
+                || !(owner instanceof PsiClass || owner instanceof PsiMethod || owner instanceof PsiField)
+                || !(owner instanceof PsiCompiledElement)) {
             return null;
         }
 


### PR DESCRIPTION
## Summary

- prepare the `0.1.0-alpha.1` alpha-channel release candidate and align Qodana/GitHub Actions tooling
- make draft creation non-destructive and Marketplace publication explicitly maintainer-dispatched, credential-driven, and prerelease-gated
- document release/publish and manual IDEA smoke procedures; record dependency triage and experimental API risk
- fix provider nullability and redundant inspection findings without changing Quick Documentation behavior

## Validation

- `./gradlew check`
- `./gradlew verifyPlugin` — compatible with IDEA 2025.3, 2026.1, and configured 2026.2 EAP; remaining experimental API reports are documented
- inspected `annodoc-intellij-0.1.0-alpha.1.zip` and patched descriptor for version, ID, artifact name, and runtime boundary

## Remaining maintainer gates

- install and smoke-test the ZIP in IDEA 2025.3 and 2026.1
- validate signing only where repository secrets are available
- publish only through the documented explicit maintainer workflow