### PR TITLE
Fail closed when selecting the plugin ZIP artifact

### DIFF
--- a/.github/scripts/prepare-plugin-artifact-test.sh
+++ b/.github/scripts/prepare-plugin-artifact-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "$0")/../.." && pwd)
+artifact_script="$repository_root/.github/scripts/prepare-plugin-artifact.sh"
+test_directory=$(mktemp -d)
+trap 'rm -rf -- "$test_directory"' EXIT
+
+output_file="$test_directory/github-output"
+distribution_directory="$test_directory/distributions"
+mkdir "$distribution_directory"
+
+if GITHUB_OUTPUT="$output_file" bash "$artifact_script" "$distribution_directory"; then
+  echo "Expected artifact preparation to reject an empty distribution directory." >&2
+  exit 1
+fi
+
+archive_path="$distribution_directory/annodoc-intellij-0.1.0-alpha.1.zip"
+touch "$archive_path"
+GITHUB_OUTPUT="$output_file" bash "$artifact_script" "$distribution_directory"
+expected_output=$'filename=annodoc-intellij-0.1.0-alpha.1.zip\npath='"$archive_path"
+if [[ $(<"$output_file") != "$expected_output" ]]; then
+  echo "Artifact preparation did not write the expected GitHub Actions outputs." >&2
+  exit 1
+fi
+
+touch "$distribution_directory/second.zip"
+if GITHUB_OUTPUT="$output_file" bash "$artifact_script" "$distribution_directory"; then
+  echo "Expected artifact preparation to reject multiple plugin ZIPs." >&2
+  exit 1
+fi
+
+newline_directory="$test_directory/newline-distribution"
+mkdir "$newline_directory"
+newline_archive_name=$'annodoc\nintellij.zip'
+touch "$newline_directory/$newline_archive_name"
+if GITHUB_OUTPUT="$output_file" bash "$artifact_script" "$newline_directory"; then
+  echo "Expected artifact preparation to reject a ZIP path containing a newline." >&2
+  exit 1
+fi

--- a/.github/scripts/prepare-plugin-artifact.sh
+++ b/.github/scripts/prepare-plugin-artifact.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "Usage: $0 <distribution-directory>" >&2
+  exit 2
+fi
+
+distribution_directory=$1
+if [[ ! -d "$distribution_directory" ]]; then
+  echo "Plugin distribution directory does not exist: $distribution_directory" >&2
+  exit 1
+fi
+
+mapfile -d '' -t archives < <(
+  find "$distribution_directory" -maxdepth 1 -type f -name '*.zip' -print0 | LC_ALL=C sort -z
+)
+
+if (( ${#archives[@]} != 1 )); then
+  echo "Expected exactly one plugin ZIP in $distribution_directory, found ${#archives[@]}." >&2
+  exit 1
+fi
+
+archive_path=${archives[0]}
+archive_name=${archive_path##*/}
+if [[ "$archive_path" == *$'\n'* || "$archive_path" == *$'\r'* || "$archive_name" == *$'\n'* || "$archive_name" == *$'\r'* ]]; then
+  echo "Plugin artifact name and path must not contain a newline." >&2
+  exit 1
+fi
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set by GitHub Actions}"
+printf 'filename=%s\npath=%s\n' "$archive_name" "$archive_path" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      # Verify artifact selection fails safely before using it for the build output.
+      - name: Test Plugin Artifact Preparation
+        run: bash .github/scripts/prepare-plugin-artifact-test.sh
+
       # Build plugin
       - name: Build plugin
         run: ./gradlew buildPlugin
@@ -55,17 +59,15 @@ jobs:
       - name: Prepare Plugin Artifact
         id: artifact
         shell: bash
-        run: |
-          FILENAME=$(find "${{ github.workspace }}/build/distributions" -maxdepth 1 -name '*.zip' -printf '%f\\n')
-          test -n "$FILENAME"
-          echo "filename=${FILENAME}" >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/prepare-plugin-artifact.sh "${{ github.workspace }}/build/distributions"
 
       # Store an already-built plugin as an artifact for downloading
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifact.outputs.filename }}
-          path: ./build/distributions/${{ steps.artifact.outputs.filename }}
+          path: ${{ steps.artifact.outputs.path }}
+          if-no-files-found: error
 
   # Run tests and upload a code coverage report
   test:


### PR DESCRIPTION
## Summary

Fixes the Build workflow’s plugin ZIP artifact upload so it selects exactly one produced ZIP and fails safely otherwise.

The previous `find -printf` expression emitted a literal `\n`, which made `upload-artifact` look for a nonexistent path while only warning. The Build job therefore stayed green without publishing the plugin ZIP artifact.

This change:

- selects exactly one ZIP with newline-free outputs;
- rejects missing or ambiguous distributions before upload;
- makes `upload-artifact` fail when its path is absent; and
- runs focused shell regression coverage in the Build job.

Part of #29.

## Validation

- `bash .github/scripts/prepare-plugin-artifact-test.sh`
- `./gradlew buildPlugin`
- `./gradlew check`
