### PR TITLE
Document workflow label vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,6 @@ Implement issues on a new, dedicated issue branch using small, reasoned commits.
 
 ### Issues and pull requests
 
-Issues and PRDs live in GitHub Issues. The repository does not yet have agent-workflow labels; do not assume `ready-for-agent` or related labels exist. See `docs/agents/issue-tracker.md`.
+Issues and PRDs live in GitHub Issues. Use the workflow-label vocabulary defined in `docs/agents/triage-labels.md` and follow `docs/agents/issue-tracker.md` for tracker operations.
 
 For user-visible changes, keep `CHANGELOG.md`, the README plugin description, `plugin.xml`, and compatibility metadata consistent. See `docs/agents/pull-requests.md`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,6 +4,6 @@ Issues and PRDs live in GitHub Issues for the repository inferred from `git remo
 
 Read an issue with its body, comments, and labels before acting on it. Preview proposed issue bodies and decomposition with the maintainer before creating or materially editing issues unless the user explicitly asks for unattended publication.
 
-The repository currently has GitHub's default issue labels plus dependency-update labels, but no `needs-triage`, `needs-info`, `ready-for-agent`, or `ready-for-human` labels. Skills must not silently substitute semantically different labels. Publish without an agent-workflow label or ask the maintainer whether to create/configure the missing vocabulary.
+The repository uses GitHub's default and dependency-update labels plus the workflow vocabulary defined in `docs/agents/triage-labels.md`. Apply the label matching the issue's actual triage state; skills must not silently substitute semantically different labels.
 
 Use native sub-issues and blocking relationships when available. Otherwise, preserve relationships in explicit `Parent` and `Blocked by` sections. Do not close or mutate a parent issue merely because child slices were created.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repository's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role such as "apply the AFK-ready triage label", use the corresponding label string from this table. Do not substitute a semantically different label.


### PR DESCRIPTION
## Summary

- add the canonical triage-label mapping used by repository skills
- align `AGENTS.md` and issue-tracker guidance with the workflow labels now configured on GitHub
- preserve the distinction between maintainer triage, missing information, AFK-agent-ready work, and human-only work

## Why

The repository guidance still said that agent-workflow labels were unavailable, so issue-publishing skills could not apply an authoritative readiness label. The live labels now mirror the KlumAST vocabulary, and this PR records that vocabulary durably for future agents and maintainers.

## Validation

- `git diff main...HEAD --check`
- verified the live label names, colors, and descriptions against KlumAST
- verified issues #37 and #38 carry `ready-for-agent`

Gradle tests were not run because this changes repository guidance only.
