### PR TITLE
Add repeatable IntelliJ ZIP smoke-test projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # AnnoDoc Support for IntelliJ IDEA Changelog
 
 ## [Unreleased]
+### Added
+- Repeatable, dependency-free manual smoke-test projects for IntelliJ IDEA 2025.3 and 2026.1 plugin ZIP validation.
 
 ## [0.1.0-alpha.1]
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,4 +71,12 @@ Build a locally installable plugin ZIP with:
 ./gradlew buildPlugin
 ```
 
+Generate a clean Java smoke-test project for a supported IntelliJ IDEA line with:
+
+```shell
+./gradlew prepareManualTestProject -PmanualTestIdeaVersion=2025.3
+```
+
+See [Manual testing a plugin ZIP](docs/manual-testing.md) for the per-version installation and Quick Documentation checklist.
+
 Maintainers should follow [the release procedure](docs/releasing.md) before publishing a candidate.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,23 @@ val klumAstFixtureJar = tasks.register<Jar>("klumAstFixtureJar") {
     }
 }
 
+val manualTestLibrary = sourceSets.create("manualTestLibrary") {
+    java.srcDir("manual-test/library/src/main/java")
+}
+val manualTestConsumer = sourceSets.create("manualTestConsumer") {
+    java.srcDir("manual-test/project-template/src")
+}
+val manualTestLibraryJarFile = layout.buildDirectory.file("manual-test/fixture/annodoc-demo-library.jar")
+val manualTestLibraryJar = tasks.register<Jar>("manualTestLibraryJar") {
+    archiveFileName = manualTestLibraryJarFile.map { it.asFile.name }
+    destinationDirectory = manualTestLibraryJarFile.map { it.asFile.parentFile }
+    from(manualTestLibrary.output) {
+        exclude("META-INF/plugin.xml")
+    }
+}
+
+manualTestConsumer.compileClasspath = files(manualTestLibraryJarFile)
+
 // Configure project's dependencies
 repositories {
     mavenCentral()
@@ -133,9 +150,17 @@ changelog {
 }
 
 tasks {
+    named<JavaCompile>(manualTestConsumer.compileJavaTaskName) {
+        dependsOn(manualTestLibraryJar)
+    }
+
     test {
         dependsOn(klumAstFixtureJar)
         systemProperty("annodoc.klumAstFixtureJar", klumAstFixtureJarFile.get().asFile.absolutePath)
+    }
+
+    check {
+        dependsOn(manualTestConsumer.compileJavaTaskName)
     }
 
     wrapper {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,39 @@ val manualTestLibraryJar = tasks.register<Jar>("manualTestLibraryJar") {
 
 manualTestConsumer.compileClasspath = files(manualTestLibraryJarFile)
 
+val manualTestIdeaVersion = providers.gradleProperty("manualTestIdeaVersion").orElse("")
+val manualTestProjectDirectory = layout.buildDirectory.dir(
+    manualTestIdeaVersion.map { "manual-test/idea-$it" }
+)
+
+val prepareManualTestProject = tasks.register<Sync>("prepareManualTestProject") {
+    group = "verification"
+    description = "Builds a clean AnnoDoc smoke-test project for one supported IntelliJ IDEA line."
+    dependsOn(manualTestConsumer.compileJavaTaskName)
+
+    into(manualTestProjectDirectory)
+    from("manual-test/project-template") {
+        exclude("idea/**")
+    }
+    from("manual-test/project-template/idea") {
+        into(".idea")
+    }
+    from(manualTestLibraryJar.flatMap { it.archiveFile }) {
+        into("lib")
+    }
+    inputs.property("manualTestIdeaVersion", manualTestIdeaVersion)
+
+    doFirst {
+        val requestedVersion = inputs.properties.getValue("manualTestIdeaVersion") as String
+        val supportedVersions = setOf("2025.3", "2026.1")
+        if (requestedVersion !in supportedVersions) {
+            throw GradleException(
+                "Set -PmanualTestIdeaVersion to one of: ${supportedVersions.joinToString()}"
+            )
+        }
+    }
+}
+
 // Configure project's dependencies
 repositories {
     mavenCentral()

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -1,0 +1,39 @@
+# Manual testing a plugin ZIP
+
+Use the generated Java project to smoke-test a finished plugin ZIP in each supported IntelliJ IDEA line. Every run produces a separate clean project, so IDEA 2025.3 and 2026.1 cannot rewrite each other's project metadata.
+
+## Build the ZIP and demo project
+
+Run this from the repository root, replacing the IDEA line for the installation being tested:
+
+```shell
+./gradlew buildPlugin prepareManualTestProject -PmanualTestIdeaVersion=2025.3
+```
+
+Supported values are `2025.3` and `2026.1`. The command creates:
+
+- the installable plugin under `build/distributions/annodoc-intellij-<version>.zip`; and
+- the clean demo project under `build/manual-test/idea-<IDEA-line>`.
+
+`prepareManualTestProject` is a Gradle `Sync` task. Rerunning it restores the selected project to its template state and removes IDEA-generated or stale files from that output directory.
+
+The build performs two explicit steps:
+
+1. It compiles `manual-test/library/src/main/java` into `lib/annodoc-demo-library.jar`. That source tree declares the minimal `com.blackbuild.annodocimal.annotations.AnnoDoc` contract verbatim and applies it directly; it has no AnnoDocimal or KlumAST dependency and uses no annotation processor or AST transformation.
+2. It copies `manual-test/project-template` and links the compiled JAR as a module library with empty source and Javadoc roots.
+
+The root `check` task also compiles the template consumer against only this JAR, so fixture drift fails automated verification.
+
+## Open and test the project
+
+For each supported IDEA installation:
+
+1. Open **Settings | Plugins**, choose **Install Plugin from Disk**, select the ZIP from `build/distributions`, and restart IDEA when prompted.
+2. Choose **File | Open** and select the matching `build/manual-test/idea-<IDEA-line>` directory.
+3. Select a Java 21 SDK if IDEA cannot inherit one automatically, then wait for indexing to finish.
+4. Open `src/demo/ManualSmokeTest.java`. Put the caret on a referenced compiled declaration and invoke **View | Quick Documentation**.
+5. Work through the checklist in the generated project's `README.md`.
+
+Do not attach the library sources or generated Javadoc: the absence of both is what exercises the plugin's fallback. To repeat a run from a known state, close that project and rerun the generation command for the same IDEA line.
+
+The demo deliberately remains a plain Java project. Real KlumAST-generated API compatibility stays in the automated `KlumAstQuickDocumentationTest` fixture and does not add Groovy, KlumAST, or AnnoDocimal setup to this manual smoke test.

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,11 +24,13 @@ The plugin uses `PsiDocumentationTargetProvider` and `DocumentationTarget` becau
 
 ## Manual IDEA smoke test
 
-Automated verification cannot install into a user-managed IDEA instance. Before approving Marketplace publication, install `build/distributions/annodoc-intellij-0.1.0-alpha.1.zip` from disk in both IntelliJ IDEA 2025.3 and 2026.1, then record the following observations:
+Automated verification cannot install into a user-managed IDEA instance. Follow [Manual testing a plugin ZIP](manual-testing.md) to generate an isolated demo project, install `build/distributions/annodoc-intellij-0.1.0-alpha.1.zip` from disk in both IntelliJ IDEA 2025.3 and 2026.1, then record the following observations:
 
-1. In a plain Java project using the compiled AnnoDoc fixture without attached sources, invoke Quick Documentation on a documented type, method, field, and constructor; all should show the annotation-carried documentation.
-2. In a Groovy project using the KlumAST fixture, invoke Quick Documentation on a generated DSL API; its AnnoDoc documentation should appear without making Groovy a plugin runtime dependency.
-3. Invoke Quick Documentation where ordinary source Javadoc is available; native documentation must win.
-4. Invoke Quick Documentation on an unannotated or malformed/blank AnnoDoc declaration; no error or fabricated documentation should appear.
+1. Quick Documentation on the compiled class, interface, annotation type, record, enum, and nested structures shows their annotation-carried documentation.
+2. Quick Documentation on compiled methods, constructors, fields, generic declarations, and interface members shows readable inline markup and block tags.
+3. Ordinary source Javadoc wins over a source annotation, and a manually authored source annotation alone is not treated as compiled fallback documentation.
+4. Unannotated and blank-AnnoDoc declarations produce no error or fabricated documentation.
+
+The real KlumAST-generated compatibility case remains covered by the automated `KlumAstQuickDocumentationTest`; the manual project intentionally has no Groovy, KlumAST, or AnnoDocimal setup.
 
 If signing secrets are configured in the execution environment, run `./gradlew signPlugin verifyPluginSignature` and inspect only its success status and signed archive. Do not print or write the credential values. Otherwise, signing remains a maintainer-gated validation step.

--- a/manual-test/library/src/main/java/com/blackbuild/annodocimal/annotations/AnnoDoc.java
+++ b/manual-test/library/src/main/java/com/blackbuild/annodocimal/annotations/AnnoDoc.java
@@ -1,0 +1,12 @@
+package com.blackbuild.annodocimal.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+public @interface AnnoDoc {
+    String value();
+}

--- a/manual-test/library/src/main/java/demo/library/DocumentedAnnotation.java
+++ b/manual-test/library/src/main/java/demo/library/DocumentedAnnotation.java
@@ -1,0 +1,16 @@
+package demo.library;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@AnnoDoc("A documented annotation type used by the manual-test consumer.")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+public @interface DocumentedAnnotation {
+    @AnnoDoc("The annotation's generic-purpose text value.\n@return the configured text")
+    String value();
+}

--- a/manual-test/library/src/main/java/demo/library/DocumentedModel.java
+++ b/manual-test/library/src/main/java/demo/library/DocumentedModel.java
@@ -1,0 +1,60 @@
+package demo.library;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+
+import java.util.Map;
+
+@AnnoDoc("A {@code generic} <b>compiled class</b> containing fields, methods, and nested declarations.\n@param <T> the text value type")
+public class DocumentedModel<T extends CharSequence> {
+    @AnnoDoc("A public generic field recovered from the compiled class.")
+    public final T documentedField;
+
+    @AnnoDoc("Creates a documented model.\n@param value the model value")
+    public DocumentedModel(T value) {
+        documentedField = value;
+    }
+
+    @AnnoDoc("Returns the model value with its generic type intact.\n@return the model value")
+    public T value() {
+        return documentedField;
+    }
+
+    @AnnoDoc("Builds a one-entry map with method and class type parameters.\n@param number the numeric value\n@param <N> the numeric type\n@return a map from the model value to the number\n@throws IllegalArgumentException when the number is negative")
+    public <N extends Number> Map<T, N> indexBy(N number) {
+        if (number.doubleValue() < 0) {
+            throw new IllegalArgumentException("number must not be negative");
+        }
+        return Map.of(documentedField, number);
+    }
+
+    @AnnoDoc("A documented static nested generic class.\n@param <U> the nested value type")
+    public static final class Nested<U> {
+        private final U value;
+
+        @AnnoDoc("Creates a nested value.\n@param value the nested value")
+        public Nested(U value) {
+            this.value = value;
+        }
+
+        @AnnoDoc("Returns the nested generic value.\n@return the nested value")
+        public U value() {
+            return value;
+        }
+    }
+
+    @AnnoDoc("A documented non-static inner class.")
+    public final class Inner {
+        @AnnoDoc("Describes the enclosing model value.\n@return a readable description")
+        public String describe() {
+            return "inner:" + documentedField;
+        }
+    }
+
+    @AnnoDoc("A documented nested enum representing model state.")
+    public enum State {
+        @AnnoDoc("The model is ready for use.")
+        READY,
+        @AnnoDoc("The model has been archived.")
+        ARCHIVED
+    }
+}

--- a/manual-test/library/src/main/java/demo/library/DocumentedRecord.java
+++ b/manual-test/library/src/main/java/demo/library/DocumentedRecord.java
@@ -1,0 +1,14 @@
+package demo.library;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+
+import java.util.Objects;
+
+@AnnoDoc("A generic compiled record.\n@param <K> the key type\n@param <V> the value type")
+public record DocumentedRecord<K, V>(K key, V value) {
+    @AnnoDoc("Creates a record with non-null components.\n@param key the record key\n@param value the record value")
+    public DocumentedRecord {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+    }
+}

--- a/manual-test/library/src/main/java/demo/library/DocumentedRepository.java
+++ b/manual-test/library/src/main/java/demo/library/DocumentedRepository.java
@@ -1,0 +1,19 @@
+package demo.library;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+@AnnoDoc("A generic documented interface for looking up and transforming values.\n@param <T> the stored value type")
+public interface DocumentedRepository<T> {
+    @AnnoDoc("The default number of values requested from a repository.")
+    int DEFAULT_PAGE_SIZE = 25;
+
+    @AnnoDoc("Finds a value by identifier.\n@param id the stable identifier\n@return the matching value, if one exists")
+    Optional<T> findById(String id);
+
+    @AnnoDoc("Maps repository values while preserving generic variance.\n@param values the source values\n@param mapper the mapping function\n@param <R> the result type\n@return the mapped values")
+    <R> List<R> map(List<T> values, Function<? super T, ? extends R> mapper);
+}

--- a/manual-test/library/src/main/java/demo/library/UndocumentedType.java
+++ b/manual-test/library/src/main/java/demo/library/UndocumentedType.java
@@ -1,0 +1,12 @@
+package demo.library;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+
+public final class UndocumentedType {
+    public void unannotatedMethod() {
+    }
+
+    @AnnoDoc("   ")
+    public void blankDocumentation() {
+    }
+}

--- a/manual-test/project-template/README.md
+++ b/manual-test/project-template/README.md
@@ -1,0 +1,19 @@
+# AnnoDoc Support manual smoke test
+
+This generated Java 21 project links `lib/annodoc-demo-library.jar` without sources or Javadoc. The JAR contains a minimal verbatim `AnnoDoc` declaration and precompiled annotated examples; it has no AnnoDocimal, KlumAST, annotation-processor, or Groovy dependency.
+
+Open `src/demo/ManualSmokeTest.java`, place the caret on each referenced declaration below, and invoke **View | Quick Documentation**:
+
+- `DocumentedModel`, `new DocumentedModel<>(...)`, `documentedField`, `value()`, and generic `indexBy(...)` cover a compiled class, constructor, field, ordinary method, and generic method with block tags.
+- `DocumentedRepository`, `DEFAULT_PAGE_SIZE`, `findById(...)`, and variance-aware `map(...)` cover a generic interface and its members.
+- `DocumentedModel.Nested`, `Inner`, and `State.READY` cover static nested, non-static inner, enum, and enum-constant declarations.
+- `DocumentedRecord` and its constructor cover a generic record.
+- `DocumentedAnnotation` covers a compiled annotation type.
+- `UndocumentedType.unannotatedMethod()` and `blankDocumentation()` must not produce AnnoDoc fallback content or an error.
+
+Then open `src/demo/NativeDocumentationExamples.java`:
+
+- `nativeDocumentationWins()` must display its native source Javadoc, not the annotation value.
+- `sourceAnnotationOnly()` must not display its manually authored source annotation as fallback documentation.
+
+This directory is generated. Make fixture changes in the repository's `manual-test` sources, not here.

--- a/manual-test/project-template/annodoc-manual-test.iml
+++ b/manual-test/project-template/annodoc-manual-test.iml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_21">
+    <output url="file://$MODULE_DIR$/out/production" />
+    <output-test url="file://$MODULE_DIR$/out/test" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/out" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="annodoc-demo-library">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/annodoc-demo-library.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/manual-test/project-template/idea/misc.xml
+++ b/manual-test/project-template/idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/manual-test/project-template/idea/modules.xml
+++ b/manual-test/project-template/idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/annodoc-manual-test.iml" filepath="$PROJECT_DIR$/annodoc-manual-test.iml" />
+    </modules>
+  </component>
+</project>

--- a/manual-test/project-template/src/demo/ManualSmokeTest.java
+++ b/manual-test/project-template/src/demo/ManualSmokeTest.java
@@ -1,0 +1,42 @@
+package demo;
+
+import demo.library.DocumentedAnnotation;
+import demo.library.DocumentedModel;
+import demo.library.DocumentedRecord;
+import demo.library.DocumentedRepository;
+import demo.library.UndocumentedType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@DocumentedAnnotation("consumer")
+public final class ManualSmokeTest {
+    private final DocumentedRepository<String> repository;
+
+    public ManualSmokeTest(DocumentedRepository<String> repository) {
+        this.repository = repository;
+    }
+
+    public void exerciseCompiledDeclarations() {
+        DocumentedModel<String> model = new DocumentedModel<>("value");
+        String field = model.documentedField;
+        String value = model.value();
+        List<Integer> mapped = repository.map(List.of(value), String::length);
+        Optional<String> found = repository.findById("id");
+        Map<String, Integer> indexed = model.indexBy(mapped.getFirst());
+        int pageSize = DocumentedRepository.DEFAULT_PAGE_SIZE;
+
+        DocumentedModel.Nested<Integer> nested = new DocumentedModel.Nested<>(mapped.getFirst());
+        DocumentedModel<String>.Inner inner = model.new Inner();
+        DocumentedRecord<String, Integer> record = new DocumentedRecord<>(field, nested.value());
+        DocumentedModel.State state = DocumentedModel.State.READY;
+
+        System.out.println(found.orElse(record.key()) + inner.describe() + state + indexed + pageSize);
+    }
+
+    public void exerciseFallbackCases(UndocumentedType undocumented) {
+        undocumented.unannotatedMethod();
+        undocumented.blankDocumentation();
+    }
+}

--- a/manual-test/project-template/src/demo/NativeDocumentationExamples.java
+++ b/manual-test/project-template/src/demo/NativeDocumentationExamples.java
@@ -1,0 +1,19 @@
+package demo;
+
+import com.blackbuild.annodocimal.annotations.AnnoDoc;
+
+public final class NativeDocumentationExamples {
+    /** Native source Javadoc must keep precedence over annotation-carried documentation. */
+    @AnnoDoc("This annotation text must not replace native source Javadoc.")
+    public void nativeDocumentationWins() {
+    }
+
+    @AnnoDoc("Source annotations are outside the plugin's compiled-declaration fallback.")
+    public void sourceAnnotationOnly() {
+    }
+
+    public void exerciseSourceDeclarations() {
+        nativeDocumentationWins();
+        sourceAnnotationOnly();
+    }
+}


### PR DESCRIPTION
## Summary

- add a dependency-free compiled AnnoDoc fixture covering classes, interfaces, fields, constructors, generics, records, annotations, enums, and nested types
- add a Gradle task that creates clean, isolated manual-test projects for IntelliJ IDEA 2025.3 and 2026.1 with the fixture JAR linked from `lib/`
- document plugin ZIP installation, project generation, smoke-test cases, and reset behavior

## Why

Finished plugin ZIPs need a quick and repeatable manual validation path for every supported IntelliJ IDEA line. The generated project exercises compiled annotation-carried documentation without KlumAST, Groovy, AnnoDocimal processors, attached sources, or generated Javadoc.

## Validation

- `./gradlew check --console=plain`
- `./gradlew buildPlugin prepareManualTestProject -PmanualTestIdeaVersion=2025.3 --console=plain`
- `./gradlew prepareManualTestProject -PmanualTestIdeaVersion=2026.1 --console=plain`
- compiled the generated consumer project directly with Java 21
- validated the generated IntelliJ project XML
- completed separate Standards and Spec reviews
