### PR TITLE
Remove obsolete Kover coverage upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
 
-  # Run tests and upload a code coverage report
+  # Run tests
   test:
     name: Test
     needs: [ build ]
@@ -104,13 +104,6 @@ jobs:
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
-
-      # Upload the Kover report to CodeCov
-      - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v5
-        with:
-          files: ${{ github.workspace }}/build/reports/kover/report.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   # Run Qodana inspections and provide a report
   inspectCode:


### PR DESCRIPTION
## Summary

Removes the obsolete Codecov upload that referenced a Kover report no longer produced by the build.

The CI test job continues to run `./gradlew check` and preserves failed-test report artifacts.

## Validation

- `git diff --check`
- `./gradlew check`